### PR TITLE
decode without length table

### DIFF
--- a/src/streamvbyte.c
+++ b/src/streamvbyte.c
@@ -262,10 +262,10 @@ size_t streamvbyte_encode(uint32_t *in, uint32_t count, uint8_t *out) {
 
 static inline __m128i _decode_avx(uint32_t key,
                                   const uint8_t *__restrict__ *dataPtrPtr) {
-  uint8_t len = lengthTable[key];
+  uint8_t len;
   __m128i Data = _mm_loadu_si128((__m128i *)*dataPtrPtr);
   __m128i Shuf = *(__m128i *)&shuffleTable[key];
-
+  len = _mm_extract_epi8(Shuf, 12 + (key >> 6) ) + 1;
   Data = _mm_shuffle_epi8(Data, Shuf);
   *dataPtrPtr += len;
   return Data;

--- a/src/streamvbyte.c
+++ b/src/streamvbyte.c
@@ -264,8 +264,9 @@ static inline __m128i _decode_avx(uint32_t key,
                                   const uint8_t *__restrict__ *dataPtrPtr) {
   uint8_t len;
   __m128i Data = _mm_loadu_si128((__m128i *)*dataPtrPtr);
-  __m128i Shuf = *(__m128i *)&shuffleTable[key];
-  len = _mm_extract_epi8(Shuf, 12 + (key >> 6) ) + 1;
+  uint8_t *pshuf = &shuffleTable[key];
+  __m128i Shuf = *(__m128i *)pshuf;
+  len = pshuf[12 + (key >> 6)] + 1;
   Data = _mm_shuffle_epi8(Data, Shuf);
   *dataPtrPtr += len;
   return Data;


### PR DESCRIPTION
This works on clang-4.0, but the pextrb intrinsic throws errors on gcc:

/usr/lib/gcc/x86_64-linux-gnu/6/include/smmintrin.h:443:27: error: selector must be an integer constant in the range 0..15
    return (unsigned char) __builtin_ia32_vec_ext_v16qi ((__v16qi)__X, __N);
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
I believe this is simply wrong, as the arg is a const int, but not a constant.  

Performance on clang is *exactly* the same:  

kendall@skylake:~/streamvbyte$ ./perf
time = 0.036000  1388888960.000000 uints/sec
compsize=1281422 compsize2 = 1281422
Compressed 500000 integers down to 1281422 bytes.
