### PR TITLE
Add CMakeLists.txt to streamvbyte

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 # this is the official list of authors for copyright purposes
 Daniel Lemire
-Kendall Willets 
+Kendall Willets
+Alexander Gallego

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 3.3)
+project(STREAMVBYTE VERSION "0.0.1")
+cmake_policy(SET CMP0065 OLD)
+enable_testing()
+set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -v" )
+set(BASE_FLAGS
+  "-std=c99"
+  "-fPIC"
+  "-Wextra"
+  "-pedantic"
+  "-Wshadow"
+)
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+  set(BASE_FLAGS
+    ${BASE_FLAGS}
+    "-O0"
+    "-ggdb"
+    )
+else()
+  set(BASE_FLAGS
+    ${BASE_FLAGS}
+    "-O3"
+    "-g"
+    )
+endif()
+# test for arm
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*)")
+   set(BASE_FLAGS
+    ${BASE_FLAGS}
+    "-D__ARM_NEON__"
+    )
+endif()
+
+# build libs
+include_directories(
+  ${PROJECT_SOURCE_DIR}/include
+  )
+set(STREAMVBYTE_SRCS
+  ${PROJECT_SOURCE_DIR}/src/streamvbyte.c
+  ${PROJECT_SOURCE_DIR}/src/streamvbytedelta.c
+  )
+add_library(streamvbyte_static STATIC "${STREAMVBYTE_SRCS}")
+target_link_libraries(streamvbyte_static ${BASE_FLAGS})
+add_library(streamvbyte SHARED "${STREAMVBYTE_SRCS}")
+target_link_libraries(streamvbyte ${BASE_FLAGS})
+install(FILES
+  ${PROJECT_SOURCE_DIR}/include/streamvbyte.h
+  ${PROJECT_SOURCE_DIR}/include/streamvbytedelta.h
+  DESTINATION include
+  )
+install(
+  TARGETS streamvbyte streamvbyte_static
+  DESTINATION lib)
+
+# build programs
+
+# example
+add_executable (example ${PROJECT_SOURCE_DIR}/example.c)
+target_link_libraries (example streamvbyte_static)
+# perf
+add_executable (perf ${PROJECT_SOURCE_DIR}/tests/perf.c)
+target_link_libraries (perf streamvbyte_static)
+# decode perf
+add_executable (decode_perf ${PROJECT_SOURCE_DIR}/tests/decode_perf.c)
+target_link_libraries(decode_perf streamvbyte_static)
+# writeseq
+add_executable (writeseq ${PROJECT_SOURCE_DIR}/tests/writeseq.c)
+target_link_libraries (writeseq streamvbyte_static)
+# perf
+add_executable (unit ${PROJECT_SOURCE_DIR}/tests/unit.c)
+target_link_libraries (unit streamvbyte_static)
+
+
+# add unit tests
+add_test(NAME unit COMMAND unit)
+add_custom_target(check
+  COMMAND ctest --output-on-failure
+  DEPENDS unit)

--- a/README.md
+++ b/README.md
@@ -20,10 +20,30 @@ This library is used by [UpscaleDB](https://github.com/cruppstahl/upscaledb), th
 
 
 
-Usage:
+Usage with Makefile:
 
       make
       ./unit
+
+Usage with CMake:
+
+The cmake build system also offers a `libstreamvbyte_static.a` in addition to
+`libstreamvbyte.so`. 
+
+`-DCMAKE_INSTALL_PREFIX:PATH=/path/to/install` is optional. 
+Defaults to /usr/local{include,lib}
+
+```
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release \
+         -DCMAKE_INSTALL_PREFIX:PATH=/path/to/install \
+make install
+
+# run the tests like:
+ctest -V
+
+```
 
 See example.c for an example.
 


### PR DESCRIPTION
Currently, there is no option to install other than to
install the library, headers in a global scope. This doesn't play
nice with other build systems.

With this file a user can simply do:

```
mkdir build
cd build
cmake .. -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX:PATH=/path/to/install
make -j8 install

```

In addition, I added tests/unit to the unit test framework of cmake
so that you can do ctest -V and you would get:

```
Test project /home/agallego/workspace/streamvbyte/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: unit

1: Test command: /home/agallego/workspace/streamvbyte/build/unit
1: Test timeout computed to be: 9.99988e+06
1: Code looks good.
1: And you have a little endian architecture.
1: Warning: you tested non-vectorized code.
1/1 Test #1: unit .............................   Passed    0.02 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.02 sec
```