### PR TITLE
CMake: allow parent project to disable unit tests for streamvbyte

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.3)
 project(STREAMVBYTE VERSION "0.0.1")
 cmake_policy(SET CMP0065 OLD)
-enable_testing()
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -v" )
 set(BASE_FLAGS
@@ -71,9 +70,12 @@ target_link_libraries (writeseq streamvbyte_static)
 add_executable (unit ${PROJECT_SOURCE_DIR}/tests/unit.c)
 target_link_libraries (unit streamvbyte_static)
 
-
-# add unit tests
-add_test(NAME unit COMMAND unit)
-add_custom_target(check
-  COMMAND ctest --output-on-failure
-  DEPENDS unit)
+option(STREAMVBYTE_ENABLE_TESTS "enable unit tests for streamvbyte" ON)
+if(STREAMVBYTE_ENABLE_TESTS)
+    enable_testing()
+    # add unit tests
+    add_test(NAME unit COMMAND unit)
+    add_custom_target(check
+        COMMAND ctest --output-on-failure
+    DEPENDS unit)
+endif()


### PR DESCRIPTION
While integrating into another cmake project via add_subdirectory()
the target `check` might already be defined by a parent directory.

In addition, on a parent project when you run its unit tests
you don't want child project unit tests to run

For example, this won't build the unit tests:
```sh
cmake -DSTREAMVBYTE_ENABLE_TESTS=OFF .. 

```