### PR TITLE
Turn on position independent code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(STREAMVBYTE_SRCS
   ${PROJECT_SOURCE_DIR}/src/streamvbyte_0124_encode.c
   ${PROJECT_SOURCE_DIR}/src/streamvbyte_0124_decode.c
    )
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_library(streamvbyte_static STATIC "${STREAMVBYTE_SRCS}")
 target_link_libraries(streamvbyte_static ${BASE_FLAGS})
 add_library(streamvbyte SHARED "${STREAMVBYTE_SRCS}")


### PR DESCRIPTION
Turn on position independent code so a static library can  [packaged](https://github.com/iiSeymour/pystreamvbyte/issues/2) with the Python bindings.