### PR TITLE
Msvc 2017 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ else()
     "-g"
     )
 endif()
+if (MSVC)
+    add_definitions(
+        "-D__restrict__=__restrict"
+        )
+endif()
 # test for arm
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*)")
    set(BASE_FLAGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,10 +93,13 @@ MESSAGE( STATUS "CMAKE_C_FLAGS_RELEASE: " ${CMAKE_C_FLAGS_RELEASE} )
 # example
 add_executable (example ${PROJECT_SOURCE_DIR}/example.c)
 target_link_libraries (example streamvbyte_static)
-# perf
-add_executable (perf ${PROJECT_SOURCE_DIR}/tests/perf.c)
-target_link_libraries (perf streamvbyte_static)
-target_link_libraries(perf m)
+
+if(NOT MSVC)
+    # perf
+    add_executable (perf ${PROJECT_SOURCE_DIR}/tests/perf.c)
+    target_link_libraries (perf streamvbyte_static)
+    target_link_libraries(perf m)
+endif()
 # writeseq
 add_executable (writeseq ${PROJECT_SOURCE_DIR}/tests/writeseq.c)
 target_link_libraries (writeseq streamvbyte_static)


### PR DESCRIPTION
`sys/resource` does not exist on windows: https://pubs.opengroup.org/onlinepubs/7908799/xsh/sysresource.h.html

`__restrict__` is instead `__restrict` on msvc.