### PR TITLE
Adds optional function to compute required memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+unit
+dynunit
+writeseq
+perf
+example
+
 # Object files
 *.o
 *.ko

--- a/include/streamvbyte.h
+++ b/include/streamvbyte.h
@@ -26,6 +26,8 @@ size_t streamvbyte_encode(const uint32_t *in, uint32_t length, uint8_t *out);
 size_t streamvbyte_encode_0124(const uint32_t *in, uint32_t length, uint8_t *out);
 
 // return the maximum number of compressed bytes given length input integers
+// in the worst case we overestimate data bytes required by four, see below
+// for a function you can run upfront over your data to compute allocations
 static inline size_t streamvbyte_max_compressedbytes(const uint32_t length) {
    // number of control bytes:
    size_t cb = (length + 3) / 4;
@@ -34,7 +36,24 @@ static inline size_t streamvbyte_max_compressedbytes(const uint32_t length) {
    return cb + db;
 }
 
+// return the exact number of compressed bytes given length input integers
+// runtime in O(n) wrt. in; use streamvbyte_max_compressedbyte if you
+// care about speed more than potentially over-allocating memory
+static inline size_t streamvbyte_compressedbytes(const uint32_t *in, uint32_t length) {
+   // number of control bytes:
+   size_t cb = (length + 3) / 4;
+   // maximum number of control bytes:
+   size_t db = 0;
+   for (uint32_t c = 0; c < length; c++) {
+      uint32_t val = in[c];
 
+      if (val < (1 << 8)) db += 1;
+      else if (val < (1 << 16)) db += 2;
+      else if (val < (1 << 24)) db += 3;
+      else db += 4;
+   }
+   return cb + db;
+}
 
 
 // Read "length" 32-bit integers in varint format from in, storing the result in out.

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -191,12 +191,42 @@ int aqrittests() {
   return 0;
 }
 
+int compressedbytestests() {
+  const uint32_t *empty = 0;
+
+  if (streamvbyte_compressedbytes(empty, 0) != 0) {
+    return -1;
+  }
+
+  uint32_t small[] = {1, 1, 1, 1};
+
+  if (streamvbyte_compressedbytes(small, 4) != (1 + (4 * 1))) {
+    return -1;
+  }
+
+  uint32_t big[] = {260, 260, 260, 260};
+
+  if (streamvbyte_compressedbytes(big, 4) != (1 + (4 * 2))) {
+    return -1;
+  }
+
+  uint32_t biggest[] = {-1, -1, -1, -1};
+
+  if (streamvbyte_compressedbytes(biggest, 4) != (1 + (4 * 4))) {
+    return -1;
+  }
+
+  return 0;
+}
+
 int main() {
   if(zigzagtests() == -1)
     return -1;
   if (basictests() == -1)
     return -1;
   if (aqrittests() == -1)
+    return -1;
+  if (compressedbytestests() == -1)
     return -1;
   printf("Code looks good.\n");
   if (isLittleEndian()) {


### PR DESCRIPTION
For #32 - please read for context. Sometimes it's better to trade off encoding runtime for reduced peak memory allocation.

Fixes https://github.com/lemire/streamvbyte/issues/32