### PR TITLE
Makes zigzag encoding and decoding save wrt. undefined behavior, see #28

### DIFF
--- a/src/streamvbyte_zigzag.c
+++ b/src/streamvbyte_zigzag.c
@@ -2,7 +2,7 @@
 
 static inline
 uint32_t _zigzag_encode_32 (int32_t val) {
-	return (val + val) ^ (val >> 31);
+	return ((uint32_t)val << (uint32_t)1) ^ (uint32_t)(-(int32_t)((uint32_t)val >> (uint32_t)31));
 }
 
 void zigzag_encode(const int32_t * in, uint32_t * out, size_t N) {
@@ -19,7 +19,7 @@ void zigzag_delta_encode(const int32_t * in, uint32_t * out, size_t N, int32_t p
 
 static inline
 int32_t _zigzag_decode_32 (uint32_t val) {
-	return (val >> 1) ^ -(val & 1);
+	return (int32_t)((val >> (uint32_t)1) ^ (uint32_t)(-(int32_t)(val & (uint32_t)1)));
 }
 
 

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -47,6 +47,36 @@ int zigzagtests() {
     return isok;
 }
 
+// Fixtures from https://developers.google.com/protocol-buffers/docs/encoding#signed_integers
+int zigzagfixturestests() {
+  const int32_t original[] = {0, -1, 1, -2, 2147483647, -2147483648};
+  const uint32_t encoded[] = {0,  1, 2,  3, 4294967294,  4294967295};
+
+  uint32_t out[] = {0xaaaaaaaa, 0xaaaaaaaa, 0xaaaaaaaa, 0xaaaaaaaa, 0xaaaaaaaa, 0xaaaaaaaa};
+
+  zigzag_encode(original, out, 6);
+
+  for (size_t i = 0; i < 6; ++i) {
+    if (encoded[i] != out[i]) {
+      printf("[zigzag_encode] %ju != %ju\n", (uintmax_t)encoded[i], (uintmax_t)out[i]);
+      return -1;
+    }
+  }
+
+  int32_t roundtrip[] = {0x55555555, 0x55555555, 0x55555555, 0x55555555, 0x55555555, 0x55555555};
+
+  zigzag_decode((const uint32_t *)out, roundtrip, 6);
+
+  for (size_t i = 0; i < 6; ++i) {
+    if (original[i] != roundtrip[i]) {
+      printf("[zigzag_decode] %jd != %jd\n", (intmax_t)original[i], (intmax_t)roundtrip[i]);
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
 // return -1 in case of failure
 int basictests() {
   int N = 4096;


### PR DESCRIPTION
This changes the zigzag encoding and decoding implementation so that we never run into undefined behavior with signed integer overflows. See thread starting at https://github.com/lemire/streamvbyte/issues/28#issuecomment-873645608 cc @lemire 