### PR TITLE
Fix __m128i init when building with clang-cl

### DIFF
--- a/src/streamvbytedelta_x64_decode.c
+++ b/src/streamvbytedelta_x64_decode.c
@@ -40,12 +40,8 @@ STREAMVBYTE_UNTARGET_REGION
 STREAMVBYTE_TARGET_SSE41
 static inline __m128i _write_16bit_sse41_d1(uint32_t *out, __m128i Vec,
                                           __m128i Prev) {
-#ifndef _MSC_VER
-  __m128i High16To32 = {0xFFFF0B0AFFFF0908, 0xFFFF0F0EFFFF0D0C};
-#else
-  __m128i High16To32 = {8,  9,  -1, -1, 10, 11, -1, -1,
-                        12, 13, -1, -1, 14, 15, -1, -1};
-#endif
+  __m128i High16To32 = _mm_set_epi64x(0xFFFF0F0EFFFF0D0CLL,
+                                      0xFFFF0B0AFFFF0908LL);
   // vec == [A B C D E F G H] (16 bit values)
   __m128i Add = _mm_slli_si128(Vec, 2);             // [- A B C D E F G]
   Prev = _mm_shuffle_epi32(Prev, BroadcastLastXMM); // [P P P P] (32-bit)


### PR DESCRIPTION
clang-cl defines __m128i as a pair of long long values. Setting it to `{8, 9, ...}` results in a warning and resulting value of __m128i = `{8, 9}`

Fixes the following warning: 
streamvbytedelta_x64_decode.c(46,33): warning : excess elements in vector initializer [-Wexcess-initializers]