### PR TITLE
Fix build on clang-cl 15.0

### DIFF
--- a/src/streamvbyte_isadetection.h
+++ b/src/streamvbyte_isadetection.h
@@ -47,6 +47,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #if defined(_MSC_VER)
 /* Microsoft C/C++-compatible compiler */
 #include <intrin.h>
+#include <tmmintrin.h>
+#include <smmintrin.h>
 #elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
 /* GCC-compatible compiler, targeting x86/x86-64 */
 #include <x86intrin.h>


### PR DESCRIPTION
For me at least in VS2022 16.4, when using clang-cl (15.0), it does not build since some SSE3 or SSE4 intrinsics are being compiled, without including the headers that define them.