### PR TITLE
Update actions/checkout in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
           - {compiler: gcc-12}
           - {compiler: clang}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use cmake (debug)
         run: |
           mkdir builddebug &&

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -23,7 +23,7 @@ jobs:
           - {compiler: clang}
           - {compiler: clang-11}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use cmake (debug)
         run: |
           mkdir builddebug &&

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -26,7 +26,7 @@ jobs:
           - {compiler: clang-13}
           - {compiler: clang}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use cmake (debug)
         run: |
           mkdir builddebug &&

--- a/.github/workflows/vs.yml
+++ b/.github/workflows/vs.yml
@@ -29,7 +29,7 @@ jobs:
           - {gen: Visual Studio 17 2022, mode: -T ClangCL, arch: x64, static: OFF}
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Configure
       run: |
         cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} "${{matrix.mode}}" -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_COMPETITION=OFF -DSIMDJSON_BUILD_STATIC=${{matrix.static}} -DSTREAMVBYTE_ENABLE_EXAMPLES=ON -DSTREAMVBYTE_ENABLE_TESTS=ON -DSTREAMVBYTE_WALL=ON -DSTREAMVBYTE_WERROR=ON -B build

--- a/.github/workflows/vs16.yml
+++ b/.github/workflows/vs16.yml
@@ -29,7 +29,7 @@ jobs:
           - {gen: Visual Studio 16 2019, mode: -T ClangCL, arch: x64, static: OFF}
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Configure
       run: |
         cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} "${{matrix.mode}}" -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_COMPETITION=OFF -DSIMDJSON_BUILD_STATIC=${{matrix.static}} -DSTREAMVBYTE_ENABLE_EXAMPLES=ON -DSTREAMVBYTE_ENABLE_TESTS=ON -DSTREAMVBYTE_WALL=ON -DSTREAMVBYTE_WERROR=ON -B build


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflows to its newest major version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.5.2
> - Fix api endpoint for GHES
>
> ## v3.5.1
> - Fix slow checkout on Windows
>
> ## v3.5.0
> - Add new public key for known_hosts
>
> ## v3.4.0
> - Upgrade codeql actions to v2
> - Upgrade dependencies
> - Upgrade @actions/io
>
> ## v3.3.0
> - Implement branch list using callbacks from exec function
> - Add in explicit reference to private checkout options
> - Fix comment typos
>
> ## v3.2.0
> - Add GitHub Action to perform release
> - Fix status badge
> - Replace datadog/squid with ubuntu/squid Docker image
> - Wrap pipeline commands for submoduleForeach in quotes
> - Update @actions/io to 1.1.2
> - Upgrading version to 3.2.0
>
> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16

Still using v2 of `actions/checkout` will generate some warning like in this run: https://github.com/lemire/streamvbyte/actions/runs/5030115995

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/checkout`, because v3 uses Node.js 16.