### PR TITLE
CMake: relocatable shared lib on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,4 @@
 cmake_minimum_required(VERSION 3.3)
-
-set(CMAKE_MACOSX_RPATH OFF)
 project(STREAMVBYTE VERSION "1.0.0")
 
 set(STREAMVBYTE_LIB_VERSION "1.0.0" CACHE STRING "streamvbyte library version")


### PR DESCRIPTION
remove `set(CMAKE_MACOSX_RPATH OFF)` to allow installing relocatable shared lib for macOS