### PR TITLE
Add validation functions and fixup sanitizer build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,6 @@ if(STREAMVBYTE_SANITIZE)
         -fno-omit-frame-pointer
         -fno-sanitize-recover=all
     )
-    add_compile_definitions(ASAN_OPTIONS=detect_leaks=1)
 endif()
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,11 @@ if(STREAMVBYTE_SANITIZE)
         -fno-omit-frame-pointer
         -fno-sanitize-recover=all
     )
+    add_link_options(
+        -fsanitize=address
+        -fno-omit-frame-pointer
+        -fno-sanitize-recover=all
+    )
     add_compile_definitions(ASAN_OPTIONS=detect_leaks=1)
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,10 @@ writeseq: ./tests/writeseq.c    $(HEADERS) $(OBJECTS)
 	$(CC) $(CFLAGS) -o writeseq ./tests/writeseq.c -Iinclude  $(OBJECTS)
 
 unit: ./tests/unit.c    $(HEADERS) $(OBJECTS)
-	$(CC) $(CFLAGS) -o unit ./tests/unit.c -Iinclude  $(OBJECTS)
+	$(CC) $(CFLAGS) -o unit ./tests/unit.c -Iinclude -Isrc  $(OBJECTS)
 
 dynunit: ./tests/unit.c    $(HEADERS) $(LIBNAME) $(LNLIBNAME)
-	$(CC) $(CFLAGS) -o dynunit ./tests/unit.c -Iinclude  -L. -lstreamvbyte
+	$(CC) $(CFLAGS) -o dynunit ./tests/unit.c -Iinclude -Isrc  -L. -lstreamvbyte
 
 clean:
 	rm -f unit *.o $(LIBNAME) $(LNLIBNAME)  example shuffle_tables perf writeseq dynunit

--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ information along with the compressed stream.
 During decoding, the library may read up to `STREAMVBYTE_PADDING` extra bytes
 from the input buffer (these bytes are read but never used).
 
+To verify that the expected size of a stream is correct you may validate it before
+decoding:
+```C
+// compressedbuffer, compsize, recovdata, N are as above
+if (streamvbyte_validate_stream(compressedbuffer, compsize, N)) {
+    // the stream is safe to decode
+    streamvbyte_decode(compressedbuffer, recovdata, N);
+} else {
+    // there's a mismatch between the expected size of the data (N) and the contents of
+    // the stream, so performing a decode is unsafe since the behaviour is undefined
+}
+```
+
 
 
 

--- a/include/streamvbyte.h
+++ b/include/streamvbyte.h
@@ -1,6 +1,7 @@
 #ifndef INCLUDE_STREAMVBYTE_H_
 #define INCLUDE_STREAMVBYTE_H_
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -65,6 +66,17 @@ size_t streamvbyte_decode(const uint8_t* in, uint32_t* out, uint32_t length);
 // Same as streamvbyte_decode but is meant to be used for streams encoded with
 // streamvbyte_encode_0124.
 size_t streamvbyte_decode_0124(const uint8_t* in, uint32_t* out, uint32_t length);
+
+// Validate an encoded stream.
+// This can be used to validate that data received from an untrusted source (disk, network,
+// etc...) has a valid length stored alongside it.
+// "inLength" is the size of the encoded data "in", and "outLength" is the expected number
+// of integers that were compressed.
+bool streamvbyte_validate_stream(const uint8_t* in, uint32_t inLength, uint32_t outLength);
+
+// Same as streamvbyte_validate_stream but is meant to be used for streams encoded with
+// streamvbyte_encode_0124.
+bool streamvbyte_validate_stream_0124(const uint8_t* in, uint32_t inLength, uint32_t outLength);
 
 #ifdef __cplusplus
 }

--- a/include/streamvbyte.h
+++ b/include/streamvbyte.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #define STREAMVBYTE_PADDING 16
 
-// Encode an array of a given length read from in to bout in varint format.
+// Encode an array of a given length read from in to out in varint format.
 // Returns the number of bytes written.
 // The number of values being stored (length) is not encoded in the compressed stream,
 // the caller is responsible for keeping a record of this length.

--- a/include/streamvbyte.h
+++ b/include/streamvbyte.h
@@ -72,11 +72,11 @@ size_t streamvbyte_decode_0124(const uint8_t* in, uint32_t* out, uint32_t length
 // etc...) has a valid length stored alongside it.
 // "inLength" is the size of the encoded data "in", and "outLength" is the expected number
 // of integers that were compressed.
-bool streamvbyte_validate_stream(const uint8_t* in, uint32_t inLength, uint32_t outLength);
+bool streamvbyte_validate_stream(const uint8_t* in, size_t inLength, uint32_t outLength);
 
 // Same as streamvbyte_validate_stream but is meant to be used for streams encoded with
 // streamvbyte_encode_0124.
-bool streamvbyte_validate_stream_0124(const uint8_t* in, uint32_t inLength, uint32_t outLength);
+bool streamvbyte_validate_stream_0124(const uint8_t* in, size_t inLength, uint32_t outLength);
 
 #ifdef __cplusplus
 }

--- a/include/streamvbytedelta.h
+++ b/include/streamvbytedelta.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-// Encode an array of a given length read from in to bout in StreamVByte format.
+// Encode an array of a given length read from in to out in StreamVByte format.
 // Returns the number of bytes written.
 // The number of values being stored (length) is not encoded in the compressed stream,
 // the caller is responsible for keeping a record of this length. The pointer "in" should

--- a/src/streamvbyte_0124_decode.c
+++ b/src/streamvbyte_0124_decode.c
@@ -200,9 +200,21 @@ bool streamvbyte_validate_stream_0124(const uint8_t *in, size_t inCount,
 
   // Accumulate the key sizes in a wider type to avoid overflow
   const uint8_t *keyPtr = in;
+  uint64_t encodedSize = 0;
+
+  // Give the compiler a hint that it can avoid branches in the inner loop
+  for (uint32_t c = 0; c < outCount / 4; c++) {
+    uint32_t key = *keyPtr++;
+    for (uint8_t shift = 0; shift < 8; shift += 2) {
+      const uint8_t code = (key >> shift) & 0x3;
+      encodedSize += (1 << code) >> 1;
+    }
+  }
+  outCount &= 3;
+
+  // Process the remainder one at a time
   uint8_t shift = 0;
   uint32_t key = *keyPtr++;
-  uint64_t encodedSize = 0;
   for (uint32_t c = 0; c < outCount; c++) {
     if (shift == 8) {
       shift = 0;

--- a/src/streamvbyte_0124_decode.c
+++ b/src/streamvbyte_0124_decode.c
@@ -183,7 +183,7 @@ size_t streamvbyte_decode_0124(const uint8_t *in, uint32_t *out, uint32_t count)
   return (size_t)(svb_decode_scalar(out, keyPtr, dataPtr, count) - in);
 }
 
-bool streamvbyte_validate_stream_0124(const uint8_t *in, uint32_t inCount,
+bool streamvbyte_validate_stream_0124(const uint8_t *in, size_t inCount,
                                       uint32_t outCount) {
   if (inCount == 0 || outCount == 0)
     return inCount == outCount;

--- a/src/streamvbyte_0124_decode.c
+++ b/src/streamvbyte_0124_decode.c
@@ -181,5 +181,37 @@ size_t streamvbyte_decode_0124(const uint8_t *in, uint32_t *out, uint32_t count)
 #endif
 
   return (size_t)(svb_decode_scalar(out, keyPtr, dataPtr, count) - in);
+}
 
+bool streamvbyte_validate_stream_0124(const uint8_t *in, uint32_t inCount,
+                                      uint32_t outCount) {
+  if (inCount == 0 || outCount == 0)
+    return inCount == outCount;
+
+  // 2-bits per key (rounded up)
+  // Note that we don't add to outCount in case it overflows
+  uint32_t keyLen = outCount / 4;
+  if (outCount & 3)
+    keyLen++;
+
+  // Check that there's enough space for the keys
+  if (keyLen > inCount)
+    return false;
+
+  // Accumulate the key sizes in a wider type to avoid overflow
+  const uint8_t *keyPtr = in;
+  uint8_t shift = 0;
+  uint32_t key = *keyPtr++;
+  uint64_t encodedSize = 0;
+  for (uint32_t c = 0; c < outCount; c++) {
+    if (shift == 8) {
+      shift = 0;
+      key = *keyPtr++;
+    }
+    const uint8_t code = (key >> shift) & 0x3;
+    encodedSize += (1 << code) >> 1;
+    shift += 2;
+  }
+
+  return encodedSize == inCount - keyLen;
 }

--- a/src/streamvbyte_decode.c
+++ b/src/streamvbyte_decode.c
@@ -105,6 +105,10 @@ bool streamvbyte_validate_stream(const uint8_t *in, size_t inCount,
   const uint8_t *keyPtr = in;
   uint64_t encodedSize = 0;
 
+#if defined(__ARM_NEON__)
+  encodedSize = svb_validate_vector(&keyPtr, &outCount);
+#endif
+
   // Give the compiler a hint that it can avoid branches in the inner loop
   for (uint32_t c = 0; c < outCount / 4; c++) {
     uint32_t key = *keyPtr++;

--- a/src/streamvbyte_decode.c
+++ b/src/streamvbyte_decode.c
@@ -86,7 +86,7 @@ size_t streamvbyte_decode(const uint8_t *in, uint32_t *out, uint32_t count) {
   return (size_t)(svb_decode_scalar(out, keyPtr, dataPtr, count) - in);
 }
 
-bool streamvbyte_validate_stream(const uint8_t *in, uint32_t inCount,
+bool streamvbyte_validate_stream(const uint8_t *in, size_t inCount,
                                  uint32_t outCount) {
   if (inCount == 0 || outCount == 0)
     return inCount == outCount;

--- a/src/streamvbyte_encode.c
+++ b/src/streamvbyte_encode.c
@@ -108,7 +108,7 @@ size_t streamvbyte_compressedbytes_0124(const uint32_t* in, uint32_t length) {
 }
 
 
-// Encode an array of a given length read from in to bout in streamvbyte format.
+// Encode an array of a given length read from in to out in streamvbyte format.
 // Returns the number of bytes written.
 size_t streamvbyte_encode(const uint32_t *in, uint32_t count, uint8_t *out) {
 #ifdef STREAMVBYTE_X64

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -47,6 +47,8 @@ static int zigzagtests(void) {
       }
     }
 
+    free(deltadataout);
+    free(deltadataback);
     free(databack);
     free(dataout);
     free(datain);

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -218,12 +218,12 @@ static int aqrittests(void) {
 
     size_t usedbytes = streamvbyte_decode(compressedbuffer, (uint32_t *)recovdata, length);
     if (compsize != usedbytes) {
-      printf("[streamvbyte_decode] code is buggy");
+      printf("[streamvbyte_decode] code is buggy i=%i\n", i);
       return -1;
     }
     for (size_t k = 0; k < length * sizeof(uint32_t); ++k) {
       if (recovdata[k] != in[k]) {
-        printf("[streamvbyte_decode] code is buggy");
+        printf("[streamvbyte_decode] code is buggy i=%i\n", i);
         return -1;
       }
     }
@@ -236,12 +236,12 @@ static int aqrittests(void) {
 
     usedbytes = streamvbyte_decode_0124(compressedbuffer, (uint32_t *)recovdata, length);
     if (compsize != usedbytes) {
-      printf("[streamvbyte_decode_0124] code is buggy");
+      printf("[streamvbyte_decode_0124] code is buggy i=%i\n", i);
       return -1;
     }
     for (size_t k = 0; k < length * sizeof(uint32_t); ++k) {
       if (recovdata[k] != in[k]) {
-        printf("[streamvbyte_decode_0124] code is buggy");
+        printf("[streamvbyte_decode_0124] code is buggy i=%i\n", i);
         return -1;
       }
     }

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -98,8 +98,9 @@ static int basictests(void) {
 
   for (uint32_t length = 0; length <= N;) {
     for (uint32_t gap = 1; gap <= 387420489; gap *= 3) {
-      for (uint32_t k = 0; k < length; ++k)
-        datain[k] = gap - 1 + ((uint32_t)rand() % 8); // sometimes start with zero
+      datain[0] = (uint32_t)rand() % 8; // sometimes start with zero
+      for (uint32_t k = 1; k < length; ++k)
+        datain[k] = datain[k - 1] + gap - 1 + (uint32_t)rand() % 8;
 
       // Default encoding: 1,2,3,4 bytes per value
       size_t compsize = streamvbyte_encode(datain, length, compressedbuffer);

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -103,6 +103,12 @@ static int basictests(void) {
 
       // Default encoding: 1,2,3,4 bytes per value
       size_t compsize = streamvbyte_encode(datain, length, compressedbuffer);
+      if (!streamvbyte_validate_stream(compressedbuffer, compsize, length)) {
+        printf("[streamvbyte_validate_stream] code is buggy length=%d gap=%d: compsize=%d\n",
+               (int)length, (int)gap, (int)compsize);
+        return -1;
+      }
+
       size_t usedbytes = streamvbyte_decode(compressedbuffer, recovdata, length);
       if (compsize != usedbytes) {
         printf("[streamvbyte_decode] code is buggy length=%d gap=%d: compsize=%d != "
@@ -120,6 +126,12 @@ static int basictests(void) {
 
       // Alternative encoding: 0,1,2,4 bytes per value
       compsize = streamvbyte_encode_0124(datain, length, compressedbuffer);
+      if (!streamvbyte_validate_stream_0124(compressedbuffer, compsize, length)) {
+        printf("[streamvbyte_validate_stream_0124] code is buggy length=%d gap=%d: compsize=%d\n",
+               (int)length, (int)gap, (int)compsize);
+        return -1;
+      }
+
       usedbytes = streamvbyte_decode_0124(compressedbuffer, recovdata, length);
       if (compsize != usedbytes) {
         printf("[streamvbyte_decode_0124] code is buggy length=%d gap=%d: compsize=%d != "
@@ -199,8 +211,12 @@ static int aqrittests(void) {
     const int length = 4;
 
     size_t compsize = streamvbyte_encode((uint32_t *)in, length, compressedbuffer);
-    size_t usedbytes = streamvbyte_decode(compressedbuffer, (uint32_t *)recovdata, length);
+    if (!streamvbyte_validate_stream(compressedbuffer, compsize, length)) {
+      printf("[streamvbyte_validate_stream] code is buggy i=%i\n", i);
+      return -1;
+    }
 
+    size_t usedbytes = streamvbyte_decode(compressedbuffer, (uint32_t *)recovdata, length);
     if (compsize != usedbytes) {
       printf("[streamvbyte_decode] code is buggy");
       return -1;
@@ -213,8 +229,12 @@ static int aqrittests(void) {
     }
 
     compsize = streamvbyte_encode_0124((uint32_t *)in, length, compressedbuffer);
-    usedbytes = streamvbyte_decode_0124(compressedbuffer, (uint32_t *)recovdata, length);
+    if (!streamvbyte_validate_stream_0124(compressedbuffer, compsize, length)) {
+      printf("[streamvbyte_validate_stream_0124] code is buggy i=%i\n", i);
+      return -1;
+    }
 
+    usedbytes = streamvbyte_decode_0124(compressedbuffer, (uint32_t *)recovdata, length);
     if (compsize != usedbytes) {
       printf("[streamvbyte_decode_0124] code is buggy");
       return -1;


### PR DESCRIPTION
This PR adds 2 new functions to validate encoded streams. These are useful when loading data from untrusted sources (disk, network, etc...) since it's typically trivial to change the uncompressed size that's stored alongside the
encoded data. This has caused crashes for us where the decode functions have trusted the corrupted size and ended up reading into an unmapped page.

I was split between doing it this way or adding a `streamvbyte_decode_safe()` which also took in the size of the input, but this appeared to be the simpler of the two for error handling (at the expense of having to traverse the data twice if you need to check and then decode).

Also as part of this PR I've fixed up the ASAN build so that it links (which caught a leak in the tests), fixed the Makefile build (presumably not used?), and fixed a typo. See individual commits for more detail.