### PR TITLE
Add explicit RISC-V scalar fallback support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ include(cmake/CPM.cmake)
 include(CheckCCompilerFlag)
 include(GNUInstallDirs)
 
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" STREAMVBYTE_SYSTEM_PROCESSOR)
+if(STREAMVBYTE_SYSTEM_PROCESSOR MATCHES "^riscv(32|64)?$")
+    message(STATUS "RISC-V target detected; streamvbyte will use the scalar fallback path")
+endif()
+
 option(STREAMVBYTE_WERROR "Treat warnings as errors." OFF)
 option(STREAMVBYTE_WALL "Emit all warnings during compilation." ON)
 
@@ -196,6 +201,27 @@ if(STREAMVBYTE_ENABLE_TESTS)
     add_executable(unit ${PROJECT_SOURCE_DIR}/tests/unit.c)
     target_link_libraries(unit streamvbyte)
     target_include_directories(unit PRIVATE ${PROJECT_SOURCE_DIR}/src)
+
+    if(NOT MSVC)
+        add_library(riscv_compile_smoke OBJECT
+            ${STREAMVBYTE_SRCS}
+            ${PROJECT_SOURCE_DIR}/tests/riscv_compile_smoke.c
+        )
+        target_include_directories(
+            riscv_compile_smoke
+            PRIVATE
+                ${PROJECT_SOURCE_DIR}/include
+                ${PROJECT_SOURCE_DIR}/src
+        )
+        target_compile_options(
+            riscv_compile_smoke
+            PRIVATE
+                -D__riscv=1
+                -D__riscv_xlen=64
+                -U__x86_64__
+                -U__amd64__
+        )
+    endif()
 
     enable_testing()
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Both the encoder and the decoder are vectorized: there is an optimized path usin
 x64 processors and one using NEON on 64-bit ARM (AArch64) processors. A portable scalar
 fallback is used otherwise, and the appropriate path is selected at runtime.
 
+For `riscv64`, the current portability path is this scalar fallback. There is no dedicated
+RVV backend yet.
+
 The approach is patent-free, the code is available under the Apache License.
 
 

--- a/src/streamvbyte_isadetection.h
+++ b/src/streamvbyte_isadetection.h
@@ -46,12 +46,29 @@ POSSIBILITY OF SUCH DAMAGE.
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define STREAMVBYTE_IS_ARM64 1
 #endif // defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+
+#if defined(__riscv)
+#define STREAMVBYTE_IS_RISCV 1
+#if defined(__riscv_xlen) && (__riscv_xlen == 64)
+#define STREAMVBYTE_IS_RISCV64 1
+#endif
+#endif
+
+#ifndef STREAMVBYTE_IS_RISCV
+#define STREAMVBYTE_IS_RISCV 0
+#endif
+
+#ifndef STREAMVBYTE_IS_RISCV64
+#define STREAMVBYTE_IS_RISCV64 0
+#endif
+
 #if defined(_MSC_VER)
 /* Microsoft C/C++-compatible compiler */
 #include <intrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
-#elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+#elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__)) &&       \
+    !defined(__riscv)
 /* GCC-compatible compiler, targeting x86/x86-64 */
 #include <x86intrin.h>
 #elif defined(__GNUC__) && defined(STREAMVBYTE_IS_ARM64)
@@ -110,7 +127,7 @@ static inline uint32_t dynamic_streamvbyte_detect_supported_architectures(void) 
 
 #endif
 
-#elif defined(__x86_64__) || defined(_M_AMD64) // x64
+#elif (defined(__x86_64__) || defined(_M_AMD64)) && !defined(__riscv) // x64
 
 
 
@@ -193,7 +210,7 @@ static inline uint32_t dynamic_streamvbyte_detect_supported_architectures(void) 
 #endif // end SIMD extension detection code
 
 
-#if defined(__x86_64__) || defined(_M_AMD64) // x64
+#if (defined(__x86_64__) || defined(_M_AMD64)) && !defined(__riscv) // x64
 #define STREAMVBYTE_X64
 #if defined(__cplusplus)
 #include <atomic>

--- a/tests/riscv_compile_smoke.c
+++ b/tests/riscv_compile_smoke.c
@@ -1,0 +1,31 @@
+#include "streamvbyte.h"
+#include "streamvbytedelta.h"
+#include "streamvbyte_zigzag.h"
+#include "streamvbyte_isadetection.h"
+
+#if STREAMVBYTE_IS_RISCV != 1
+#error "expected STREAMVBYTE_IS_RISCV to be enabled"
+#endif
+
+#if STREAMVBYTE_IS_RISCV64 != 1
+#error "expected STREAMVBYTE_IS_RISCV64 to be enabled"
+#endif
+
+#ifdef STREAMVBYTE_X64
+#error "forced RISC-V smoke build must not keep STREAMVBYTE_X64"
+#endif
+
+void riscv_compile_smoke(void) {
+  uint32_t values[8] = {1, 2, 3, 255, 256, 65535, 65536, 123456789};
+  uint32_t recovered[8] = {0};
+  uint32_t zz[8] = {0};
+  int32_t signed_values[8] = {0, -1, 1, -2, 2, -3, 3, -4};
+  uint8_t buffer[128] = {0};
+  size_t encoded = streamvbyte_encode(values, 8, buffer);
+  (void)streamvbyte_decode(buffer, recovered, 8);
+  (void)streamvbyte_validate_stream(buffer, encoded, 8);
+  zigzag_encode(signed_values, zz, 8);
+  zigzag_decode(zz, signed_values, 8);
+  (void)streamvbyte_delta_encode(values, 8, buffer, 0);
+  (void)streamvbyte_delta_decode(buffer, recovered, 8, 0);
+}


### PR DESCRIPTION
## Why

`streamvbyte` already contains a portable scalar fallback, but `riscv64` was still only covered implicitly by the generic path. The source-level ISA detection logic did not expose RISC-V as an explicit target class, the build did not report that RISC-V uses the scalar path, and there was no dedicated compile smoke showing that the full implementation can be rebuilt intentionally under RISC-V macros.

This patch makes the existing fallback path explicit for RISC-V without adding RVV intrinsics or changing the SSE4.1 / NEON fast paths.

## What changed

- Updated `src/streamvbyte_isadetection.h`:
  - add explicit `STREAMVBYTE_IS_RISCV` and `STREAMVBYTE_IS_RISCV64` detection;
  - prevent forced RISC-V builds from keeping the x64 path active at the same time;
  - keep RISC-V on the existing scalar fallback path.
- Updated `CMakeLists.txt`:
  - recognize `riscv*` processor strings and print a configure-time status message that streamvbyte will use the scalar fallback path;
  - when `STREAMVBYTE_ENABLE_TESTS=ON` and the compiler supports it, add a `riscv_compile_smoke` object target that recompiles the main library sources under forced `__riscv=1` / `__riscv_xlen=64`.
- Updated `README.md`:
  - document that `riscv64` currently uses the scalar fallback and does not provide a dedicated RVV backend.
- Added `tests/riscv_compile_smoke.c`:
  - assert that the forced-RISC-V build selects the RISC-V scalar path rather than the x64 SIMD path;
  - compile public encode/decode, delta, validation, and zigzag entry points in the forced-RISC-V configuration.

## Verification

- Ran native test-enabled configure and build successfully:
  - `cmake -S . -B build-native -G Ninja -DCMAKE_BUILD_TYPE=Release -DSTREAMVBYTE_ENABLE_TESTS=ON`
  - `cmake --build build-native --parallel 4`
- Ran native tests successfully:
  - `ctest --test-dir build-native --output-on-failure`
- Ran simulated `riscv64` configure and build successfully:
  - `cmake -S . -B build-riscv-sim -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=riscv64 -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY`
  - `cmake --build build-riscv-sim --parallel 4`
- Confirmed simulated `riscv64` configure output includes:
  - `RISC-V target detected; streamvbyte will use the scalar fallback path`
- Confirmed `build-riscv-sim/build.ninja`:
  - does not reference `streamvbyte_x64_*`;
  - does not reference `streamvbyte_arm_*`;
  - does not inject `-mavx*`;
  - does not inject `-msse*`;
  - still builds the main generic sources such as `streamvbyte_encode.c`.
- Confirmed the native test-enabled build compiles the forced-RISC-V smoke object target:
  - `riscv_compile_smoke` rebuilds `${STREAMVBYTE_SRCS}` plus `tests/riscv_compile_smoke.c` under forced `__riscv=1` / `__riscv_xlen=64`.
- Verified a real `riscv64` cross-build and runtime path in `dockcross/linux-riscv64`:
  - configured with `CMAKE_C_COMPILER="$CC"`, `CMAKE_SYSTEM_NAME=Linux`, `CMAKE_SYSTEM_PROCESSOR=riscv64`, `CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY`, and `-DSTREAMVBYTE_ENABLE_EXAMPLES=ON`;
  - built the `example` target successfully with `/usr/xcc/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc`.
- Verified the produced binary is a real RISC-V executable:
  - `file` reports `ELF 64-bit LSB executable, UCB RISC-V, RVC, double-float ABI`;
  - `readelf -h` reports `Machine: RISC-V`.
- Verified the real `riscv64` build remains on the scalar path:
  - `build.ninja` does not reference `streamvbyte_x64_*`;
  - `build.ninja` does not reference `streamvbyte_arm_*`;
  - `build.ninja` does not inject `-mavx*` or `-msse*`.
- Ran the resulting binary under `qemu-riscv64` successfully:
  - output: `Compressed 5000 integers down to 6250 bytes.`

## Notes

- This is a conservative portability patch. It does not add RVV kernels, RVV dispatch, or RISC-V-specific performance tuning.
- The upstream scalar fallback already existed; this patch makes that path explicit, verifiable, and easier to reason about for `riscv64`.
- Validation now includes a real `riscv64` cross-build plus `qemu-riscv64` execution, but it still does not add RVV coverage or real RISC-V hardware testing.